### PR TITLE
Add ClientId to MQTT config section

### DIFF
--- a/gui/send_config.py
+++ b/gui/send_config.py
@@ -116,6 +116,7 @@ configs = {
         [
             Setting(command='mqtthost', description='Broker', widget_class=QLineEdit, required=True),
             Setting(command='mqttport', description='Port', widget_class=SpinBox, default=1883),
+            Setting(command='mqttclient', description='ClientID', widget_class=QLineEdit),
             Setting(command='topic', description='Topic', widget_class=QLineEdit, required=True, default='tasmota_%06X'),
             Setting(command='fulltopic', description='FullTopic', widget_class=QLineEdit, required=True, default='%prefix%/%topic%/'),
         ],


### PR DESCRIPTION
- Add MQTT ClientId to config section with `MqttClient` tasmota command

Some Cloud MQTT Brokers require  MQTT ClientId to be static and identifiable, so I thought it would be nice to set it in MQTT config section