### PR TITLE
RTS/DTR for sending config

### DIFF
--- a/tasmotizer.py
+++ b/tasmotizer.py
@@ -699,6 +699,9 @@ class Tasmotizer(QDialog):
                     self.port = QSerialPort(self.cbxPort.currentData())
                     self.port.setBaudRate(115200)
                     self.port.open(QIODevice.ReadWrite)
+                    self.port.setDataTerminalReady(0)
+                    self.port.setRequestToSend(0)
+                    sleep(.5)
                     bytes_sent = self.port.write(bytes(dlg.commands, 'utf8'))
                 except Exception as e:
                     QMessageBox.critical(self, 'Error', f'Port access error:\n{e}')


### PR DESCRIPTION
A programming device with just RTS to reset and DTR to GPIO0 works with esptool to flash code under tasmotizer, but then does not work for sending config. This is because tasmotizer leaves RTS/DTR to QSerialPort which sets active (low) even when no flow control (default) from when the port is opened until the port is closed.

By setting inactive (high) after opening the port, this therefore causes a clean reset in the same way as esptool does. The sleep allows time for tasmota to start and be ready to accept the config. Perhaps this could be based on the "self-resetting" option, or be a separate option in its own right.

I believe it should work with devices like esptool does though. Another idea that may be more generic would be some way to tell QSerialPort not to touch RTS/DTR when opening the port but I don't know how to do that.